### PR TITLE
Ignore runff test output files in github

### DIFF
--- a/tests/runff/.gitignore
+++ b/tests/runff/.gitignore
@@ -1,0 +1,4 @@
+# ignore test output files in github
+ForeFire.0.nc
+real_case.kml
+to_reload.ff


### PR DESCRIPTION
Those files are outputed by the test and we probably don't want to track or commit them to the repository