### PR TITLE
HTTP server: add MIME types for CSS and js files;

### DIFF
--- a/src/HttpCommandServer.hpp
+++ b/src/HttpCommandServer.hpp
@@ -175,6 +175,10 @@ namespace http_command {
                     return "image/jpeg";
                 else if (ext == ".json")
                     return "application/json";
+                else if (ext == ".css")
+                    return "text/css; charset=UTF-8";
+                else if (ext == ".js")
+                    return "application/javascript; charset=UTF-8";
             }
             return "application/octet-stream";
         }
@@ -249,7 +253,7 @@ namespace http_command {
                 if (fileExists("index.html"))
                     path = "index.html";
                 else if (const char* ffHome = std::getenv("FOREFIREHOME")) {
-                    std::string altIndex = std::string(ffHome) + "/tools/index.html";
+                    std::string altIndex = std::string(ffHome) + "/tools/htdocs/index.html";
                     if (fileExists(altIndex))
                         path = altIndex;
                 }


### PR DESCRIPTION
- Allow server to handle css and js files. This way we can improve slipt html, css, and js into different files
- Also fixed the path to index.html wich is inside `tools/htdocs`


observation: Filippi sorry if you were also coding on this file i can resolve conflicts that may appear