### PR TITLE
rm unecessary lines that mess the formatting

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,4 +1,3 @@
-```markdown
 # PyForeFire
 
 PyForeFire provides Python bindings for the ForeFire library, enabling users to access ForeFire’s functionality directly from Python. The bindings link against the precompiled ForeFire library and include support for NetCDF and other dependencies.
@@ -118,4 +117,3 @@ This project is licensed under the terms specified in the `LICENSE` file.
 
 - **Homepage:** [https://github.com/forefireAPI/firefront](https://github.com/forefireAPI/firefront)
 - **Repository:** [https://github.com/forefireAPI/firefront](https://github.com/forefireAPI/firefront)
-```


### PR DESCRIPTION
- Since the file is already `.md`  extension we don't need those lines, and actually they remove the formatting that yould appear
![image](https://github.com/user-attachments/assets/fb43891c-0da9-4e16-b341-2ccfdab1565c)