### PR TITLE
Faster cmake compilation (parallel) + removed warnings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.ipynb linguist-detectable=false
 *.ref filter=lfs diff=lfs merge=lfs -text
 * text=auto
+*.sh text eol=lf

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: Build ForeFire on macOS
+name: macOS
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: ForeFire build
-        run: sudo bash ./install-forefire.sh
+        run: sudo bash ./install-forefire.sh -y
 
       - name: Check version
         run: ./bin/forefire -v

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build and Test on Ubuntu  
+name: Linux
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 ---
 [![DOI](https://img.shields.io/badge/DOI-10.14195/978--989--26--0884--6_29-blue)](https://www.researchgate.net/publication/278769168_ForeFire_open-source_code_for_wildland_fire_spread_models) <!-- Or use Zenodo DOI if available -->
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-[![CI](https://github.com/forefireAPI/firefront/actions/workflows/main.yml/badge.svg)](https://github.com/forefireAPI/firefront/actions/workflows/main.yml)
+[![linuxCI](https://github.com/forefireAPI/firefront/actions/workflows/main.yml/badge.svg)](https://github.com/forefireAPI/firefront/actions/workflows/main.yml)
+[![macOSCI](https://github.com/forefireAPI/firefront/actions/workflows/macos.yml/badge.svg)](https://github.com/forefireAPI/firefront/actions/workflows/macos.yml)
 ![Language](https://img.shields.io/badge/C++-00599C?logo=c%2B%2B&logoColor=white)
 ![Language](https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=white)
 [![Documentation Status](https://readthedocs.org/projects/your-rtd-project-name/badge/?version=latest)](https://your-rtd-project-name.readthedocs.io/en/latest/?badge=latest) <!-- Add your RTD project name -->

--- a/cmake-build.sh
+++ b/cmake-build.sh
@@ -1,4 +1,11 @@
-mkdir build
-cd build
-cmake ../
-make
+#!/usr/bin/env bash
+set -e
+
+# 1. Create (or reuse) the build directory quietly
+mkdir -p build
+
+# 2. Configure into build/
+cmake -S . -B build
+
+# 3. Build in parallel on all cores
+cmake --build build -- -j"$(nproc)"

--- a/install-forefire.sh
+++ b/install-forefire.sh
@@ -2,6 +2,21 @@
 set -e
 IFS=$'\n\t'
 
+# --- parse flags
+AUTO_ANS=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -y|--yes)
+      AUTO_ANS=1
+      shift
+      ;;
+    *)
+      echo "Usage: $0 [-y|--yes]" >&2
+      exit 1
+      ;;
+  esac
+done
+
 echo -e "\n========= FOREFIRE INSTALLER ========"
 
 PROJECT_ROOT="$(pwd)"
@@ -41,7 +56,12 @@ FOREFIREHOME_LINE="export FOREFIREHOME=\"$PROJECT_ROOT\""
 if grep -qF "$BIN_PATH" "$CONFIG_FILE"; then
   echo "ForeFire already appears in your PATH in $CONFIG_FILE."
 else
-  read -p "Do you want to add ForeFire to your PATH permanently in $CONFIG_FILE? (y/n): " ans
+  if (( AUTO_ANS )); then
+    ans=y
+  else
+    read -p "Do you want to add ForeFire to your PATH permanently in $CONFIG_FILE? (y/n): " ans
+  fi
+  
   if echo "$ans" | grep -qi '^y'; then
     # Append a blank line, a comment, and the export line.
     echo "" >> "$CONFIG_FILE"

--- a/src/MultiplicativeLayer.h
+++ b/src/MultiplicativeLayer.h
@@ -93,9 +93,9 @@ public:
 	double getOriginX(	){ return baseLayer->getOriginX(); };
 	double getOriginY(){ return baseLayer->getOriginY(); };
 	double getOriginZ(){ return baseLayer->getOriginZ(); };
-	double getWidth(){ baseLayer->getWidth(); };
-	double getHeight(){ baseLayer->getHeight(); };
-	double getDepth(){ baseLayer->getDepth(); };
+	double getWidth(){ return baseLayer->getWidth(); };
+	double getHeight(){ return baseLayer->getHeight(); };
+	double getDepth(){ return baseLayer->getDepth(); };
 
 };
 


### PR DESCRIPTION
## faster build
added options to cmake
```bash
# 3. Build in parallel on all cores
cmake --build build -- -j"$(nproc)"
```

## removed warnings
added 3 returns here... 
```
	double getWidth(){ return baseLayer->getWidth(); };
	double getHeight(){ return baseLayer->getHeight(); };
	double getDepth(){ return baseLayer->getDepth(); };
```

Adding badges on readme
[![linuxCI](https://github.com/forefireAPI/firefront/actions/workflows/main.yml/badge.svg)](https://github.com/forefireAPI/firefront/actions/workflows/main.yml)
[![macOSCI](https://github.com/forefireAPI/firefront/actions/workflows/macos.yml/badge.svg)](https://github.com/forefireAPI/firefront/actions/workflows/macos.yml)