### PR TITLE
Upgrade to C++14 Standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(forefire VERSION 1.0)
 # ----------------------------------
 # Set C++ Standard
 # ----------------------------------
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # ----------------------------------

--- a/src/ANN.h
+++ b/src/ANN.h
@@ -17,11 +17,7 @@
 #include <cstring>
 #include <sstream>
 #include <stdexcept>
-// Add this helper function, preferably in a common header file
-template <typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args&&... args) {
-    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
+
 // Activation functions
 inline float sigmoid(float x) {
     return 1.0f / (1.0f + std::exp(-x));
@@ -148,7 +144,7 @@ struct Network {
                 std::vector<float> meanData(width), varianceData(width);
                 file.read(reinterpret_cast<char*>(meanData.data()), width * sizeof(float));
                 file.read(reinterpret_cast<char*>(varianceData.data()), width * sizeof(float));
-                layers.push_back(make_unique<NormalizationLayer>(meanData, varianceData));
+                layers.push_back(std::make_unique<NormalizationLayer>(meanData, varianceData));
             } else {
                 // Dense layer
                 float (*actFunc)(float) = getActivationFunction(std::string(activation));


### PR DESCRIPTION
**Reason:**
*   Enables use of modern C++ features (like `std::make_unique`).
*   Improves long-term maintainability and aligns with current practices.
*   Leverages standard library improvements.

**Changes:**
1.  **`CMakeLists.txt`:** Set `CMAKE_CXX_STANDARD` to `14` and required it.
2.  **`src/ANN.h`:** Resolved compilation ambiguity by explicitly using `std::make_unique` (now available in C++14) instead of relying on a previous custom helper function with the same name. Removed the old functions

**Verification:**
Project compiles successfully with C++14 enabled.