### PR TITLE
working build on macOs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 # Source Files
 # ----------------------------------
 file(GLOB_RECURSE SRC_FILES src/*.cpp)
+list(APPEND SRC_FILES tools/forefire/AdvancedLineEditor.cpp)
 
 # ----------------------------------
 # Shared Library Target


### PR DESCRIPTION
To implement the help command i imported advancedLineEditor CPP into the src code.
The build was workind on linux, but the actions of macOs. 
Since we are now using advancedLineEditor for the help comand, inside the library, we must add that code to compile the library
with
```
list(APPEND SRC_FILES tools/forefire/AdvancedLineEditor.cpp)
```