### PR TITLE
feat: add trigger for simulation resolution

### DIFF
--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -2003,6 +2003,44 @@ namespace libforefire
                 return normal;
             }
         }
+        if (tmpArgs[0] == "resolution")
+        {
+            double newPerimRes = getFloat("perimeterResolution", arg);
+            double newSpatialInc = getFloat("spatialIncrement", arg);
+
+            bool valid = true;
+
+            if (newPerimRes != FLOATERROR && newPerimRes <= 0.0) {
+                cout << "Error: perimeterResolution must be greater than 0." << endl;
+                valid = false;
+            }
+            if (newSpatialInc != FLOATERROR && newSpatialInc <= 0.0) {
+                cout << "Error: spatialIncrement must be greater than 0." << endl;
+                valid = false;
+            }
+            if (!valid) return error;
+            
+            FireDomain* domain = getDomain();
+            if (domain != nullptr)
+            {
+                if (newPerimRes != FLOATERROR)
+                {
+                    domain->setPerimeterResolution(newPerimRes);
+                    cout << "Updated perimeterResolution to " << newPerimRes << endl;
+                }
+                if (newSpatialInc != FLOATERROR)
+                {
+                    domain->setSpatialIncrement(newSpatialInc);
+                    cout << "Updated spatialIncrement to " << newSpatialInc << endl;
+                }
+                return normal;
+            }
+            else 
+            {
+                cout << "Error: No FireDomain available to update resolution parameters." << endl;
+                return error;
+            }
+        }
         return error;
     }
     int Command::include(const string &arg, size_t &numTabs)

--- a/src/DataBroker.cpp
+++ b/src/DataBroker.cpp
@@ -1264,7 +1264,7 @@ namespace libforefire
 
 					if (varName == "altitude" && domain->getDomainID() == 0)
 					{
-						cout << "HHHHHHHHHHHHHHH   read Altitude " << domain->getDomainID() << endl;
+						cout << "Reading Altitude " << domain->getDomainID() << endl;
 						auto altLayer = constructXYZTLayer(currentVar, SWCorner, spatialExtent, timeOrigin, Lt, -1);
 						registerLayer(varName, altLayer);
 					}

--- a/src/FireDomain.cpp
+++ b/src/FireDomain.cpp
@@ -412,6 +412,12 @@
 	 }
 	 return buffer.st_size;   
  }
+ void FireDomain::setPerimeterResolution(double res) {
+	this->perimeterResolution = res;
+ }
+ void FireDomain::setSpatialIncrement(double inc) {
+	 this->spatialIncrement = inc;
+ }
  void FireDomain::pushMultiDomainMetadataInList(size_t id, double lastTime, size_t atmoNX, size_t atmoNY, double nswx, double nswy, double nnex, double nney) {
 	 distributedDomainInfo *currentInfo = new distributedDomainInfo;
 	 currentInfo->ID = id;

--- a/src/FireDomain.h
+++ b/src/FireDomain.h
@@ -326,6 +326,9 @@ public:
 
 	size_t getFreeFluxModelIndex();
 
+	void setPerimeterResolution(double res);
+	void setSpatialIncrement(double inc);
+
     // Getter for the reference latitude.
     double getRefLatitude()  ;
 

--- a/src/SimulationParameters.cpp
+++ b/src/SimulationParameters.cpp
@@ -370,7 +370,6 @@ std::string landCoverIndexedCSV = R"(Index;Rhod;Rhol;Md;Ml;sd;sl;e;Sigmad;Sigmal
 	parameters.insert(make_pair("spatialCFLmax", "0.3"));
 	parameters.insert(make_pair("spatialIncrement", "2"));
 	parameters.insert(make_pair("spatialCFLmax", "0.3"));
-	parameters.insert(make_pair("spatialIncrement", "2"));
 	parameters.insert(make_pair("watchedProc", "-2"));
 	parameters.insert(make_pair("CommandOutputs", "0"));
 	parameters.insert(make_pair("FireDomainOutputs", "0"));


### PR DESCRIPTION
As discussed @filippi, suggesting to add a trigger for perimeterResolution and spatialIncrement. Being able to change the resolution during runtime allows e.g. to start from very small initial fire fronts, without loosing too much time during later steps due to the high resolution.