### PR TITLE
fix: double-free in FireFront cleanup

### DIFF
--- a/src/FireFront.cpp
+++ b/src/FireFront.cpp
@@ -314,7 +314,7 @@ void FireFront::splineInterp(FireNode* ifn, FFVector& nml, double& kappa){
 		d2x = new double[nspl];
 		if ( d2y!=0 ) delete [] d2y;
 		d2y = new double[nspl];
-		if ( u!=0 ) delete [] z;
+		if ( u!=0 ) delete [] u;
 		u = new double[nspl];
 		if ( z!=0 ) delete [] z;
 		z = new double[nspl];


### PR DESCRIPTION
`src/FireFront.cpp:317` guards `u` but `delete []` targets `z`. Surrounding lines all follow `if (X != 0) delete [] X;`, so this looks like a copy-paste typo. With both pointers non-null it leaks `u` and double-frees `z`.

One-character fix. Tests still pass locally.
