### PR TITLE
[tests] fix run.bash bugs

### DIFF
--- a/tests/run.bash
+++ b/tests/run.bash
@@ -61,4 +61,3 @@ else
     echo "All tests passed."
     exit 0
 fi
-./clean.bash

--- a/tests/run.bash
+++ b/tests/run.bash
@@ -41,7 +41,7 @@ fi
 
 # Run additional tests (e.g., runff and runANN)
 run_test "runff" "runff"
-run_test "runANN" "runff"  # adjust the directory if runANN is in a different location
+run_test "runANN" "runANN"
 
 # Final summary
 echo "--------------------------"


### PR DESCRIPTION
Two small bugs in `tests/run.bash`:

Line 44: `run_test "runANN" "runff"` invoked the runff test twice and reported success under the runANN label, while the runANN directory was never tested. Fixed to `run_test "runANN" "runANN"`. 

Last line: `./clean.bash` was unreachable because the preceding if/else always exits. Cleanup remains available via `make clean`.

Verified locally with `make -C tests test` (now runs both runff and runANN).

Note: this surfaces a separate pre-existing issue. `tests/runANN/result.txt.ref` was deleted in commit 9431a18 (June 2025) but `tests/runANN/run.bash` still expects it via `diff`. To address in a follow-up PR.
