### PR TITLE
fix: stop ignoring CMakeLists.txt in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ tools/cache
 tools/cmaps
 bindings/python/src/pyforefire.egg-info
 paper/jats
+#python packaging
+dist
+wheelhouse
+*.egg-info
 #python
 __pycache__
 venv
@@ -32,7 +36,8 @@ docs/doxygen/xml
 docs/doxygen/html
 
 # build
-CMakeLists.txt
+# Do not ignore CMakeLists.txt here: it is tracked, and ignoring it makes
+# packaging tools drop it from the sdist.
 build.sh
 
 #tools


### PR DESCRIPTION
Extracted from #151 (credited to @HugoFara, who wrote this fix as part of that PR).

`CMakeLists.txt` is tracked, but `.gitignore` excluded it, which makes packaging tools that read `.gitignore` to decide what to include (rather than git's own tracked-file list) silently drop it from the sdist. Also ignores common Python packaging output directories (`dist`, `wheelhouse`, `*.egg-info`) ahead of the wheel-packaging work in #151.

Standalone and unrelated to the open macOS wheel issue on #151, so merging this now unblocks it independently of that discussion.

I want to merge this first so that @HugoFara  becomes a contributor to the project to enable him to launch the actions on the repository. which are allowed only by people who alterdy contributed