### PR TITLE
chore: bump version to v2.5.0

### DIFF
--- a/src/include/Version.h
+++ b/src/include/Version.h
@@ -1,3 +1,3 @@
 #pragma once
-const char* ff_version = "v2.3.0";
+const char* ff_version = "v2.5.0";
 


### PR DESCRIPTION
Bumps `Version.h` from `v2.3.0` to `v2.5.0`.

Tag `v2.4.2` already exists (manual tag by @filippi_j for the JOSS/MesoNH sync), so `v2.3.0` was behind an already-published release. Going to `v2.5.0` keeps the version increasing and marks the long-awaited `pip install forefire` release (#151).

Not merging automatically — will merge manually after tagging/release plan is confirmed.