### PR TITLE
Build NetCDF without DAP and HDF4: halve the Linux wheel

### DIFF
--- a/tools/devops/install-netcdf-manylinux.sh
+++ b/tools/devops/install-netcdf-manylinux.sh
@@ -2,12 +2,21 @@
 #
 # Install the NetCDF stack inside a manylinux_2_28 container, for cibuildwheel.
 #
-# EPEL provides the NetCDF C library and HDF5 for both x86_64 and aarch64, but
-# no package for the legacy C++4 API that ForeFire's DataBroker includes as
-# <netcdf>, so that one is built from source. Everything lands in /usr/local
-# where auditwheel can find it and vendor it into the wheel.
+# HDF5 comes from EPEL. The NetCDF C library and the C++4 API are both built
+# from source into /usr/local, where auditwheel finds them and vendors them
+# into the wheel.
+#
+# NetCDF C is built rather than installed from EPEL so that DAP and HDF4 can
+# be switched off. EPEL enables both, and auditwheel then has to vendor their
+# entire dependency closure: DAP pulls libcurl, which drags in OpenSSL,
+# Kerberos, LDAP, libssh and a dozen more, about 10 MB across 22 libraries
+# that ForeFire never calls. macOS avoids this only because the system
+# provides libcurl. HDF4 adds another 1.4 MB, and Homebrew's NetCDF does not
+# enable it, so turning it off here also makes the two platforms agree.
 set -euo pipefail
 
+NETCDF_C_VERSION="${NETCDF_C_VERSION:-4.9.3}"
+NETCDF_C_SHA256="a474149844e6144566673facf097fea253dc843c37bc0a7d3de047dc8adda5dd"
 NETCDF_CXX4_VERSION="${NETCDF_CXX4_VERSION:-4.3.1}"
 NETCDF_CXX4_SHA256="6a1189a181eed043b5859e15d5c080c30d0e107406fbb212c8fb9814e90f3445"
 PREFIX="${PREFIX:-/usr/local}"
@@ -17,35 +26,82 @@ if [[ -f "${PREFIX}/include/netcdf" ]]; then
     exit 0
 fi
 
-echo "::group::Installing NetCDF C library from EPEL"
+echo "::group::Installing HDF5 from EPEL"
 dnf install -y epel-release
-dnf install -y netcdf-devel hdf5-devel
+dnf install -y hdf5-devel
 echo "::endgroup::"
 
-echo "::group::Building netcdf-cxx4 ${NETCDF_CXX4_VERSION}"
 workdir="$(mktemp -d)"
 trap 'rm -rf "${workdir}"' EXIT
 cd "${workdir}"
 
-tarball="netcdf-cxx4-${NETCDF_CXX4_VERSION}.tar.gz"
-curl -fsSL -o "${tarball}" \
-    "https://downloads.unidata.ucar.edu/netcdf-cxx/${NETCDF_CXX4_VERSION}/${tarball}"
-echo "${NETCDF_CXX4_SHA256}  ${tarball}" | sha256sum --check --strict
+fetch() {
+    local url="$1" tarball="$2" sha="$3"
+    curl -fsSL -o "${tarball}" "${url}"
+    echo "${sha}  ${tarball}" | sha256sum --check --strict
+    tar xzf "${tarball}"
+}
 
-tar xzf "${tarball}"
+echo "::group::Building netcdf-c ${NETCDF_C_VERSION}"
+fetch "https://downloads.unidata.ucar.edu/netcdf-c/${NETCDF_C_VERSION}/netcdf-c-${NETCDF_C_VERSION}.tar.gz" \
+      "netcdf-c-${NETCDF_C_VERSION}.tar.gz" "${NETCDF_C_SHA256}"
+cd "netcdf-c-${NETCDF_C_VERSION}"
+
+# --disable-dap and --disable-byterange both have to go: byterange is a second
+# remote-access path that links libcurl on its own. --disable-hdf4 drops
+# libmfhdf, libdf, libjpeg and libtirpc. ForeFire reads local .nc and PGD
+# files, so none of these are reachable from it.
+./configure \
+    --prefix="${PREFIX}" \
+    --enable-shared \
+    --disable-static \
+    --disable-dap \
+    --disable-byterange \
+    --disable-hdf4 \
+    --disable-libxml2 \
+    --disable-examples \
+    --disable-testsets
+make -j "$(nproc)"
+make install
+ldconfig
+cd "${workdir}"
+echo "::endgroup::"
+
+echo "::group::Building netcdf-cxx4 ${NETCDF_CXX4_VERSION}"
+fetch "https://downloads.unidata.ucar.edu/netcdf-cxx/${NETCDF_CXX4_VERSION}/netcdf-cxx4-${NETCDF_CXX4_VERSION}.tar.gz" \
+      "netcdf-cxx4-${NETCDF_CXX4_VERSION}.tar.gz" "${NETCDF_CXX4_SHA256}"
 cd "netcdf-cxx4-${NETCDF_CXX4_VERSION}"
+
+# nc-config from the netcdf-c just installed has to win over anything else on
+# PATH, so that the C++ API links the DAP-free build.
+export PATH="${PREFIX}/bin:${PATH}"
+export PKG_CONFIG_PATH="${PREFIX}/lib:${PREFIX}/lib64:${PKG_CONFIG_PATH:-}"
 
 # Autotools rather than the bundled CMake build: netcdf-cxx4 4.3.1 declares
 # `cmake_minimum_required(VERSION 2.8.12)`, and CMake 4 refuses anything below
-# 3.5. configure picks up the EPEL NetCDF through nc-config.
+# 3.5. configure picks up the NetCDF built above through nc-config.
 ./configure \
     --prefix="${PREFIX}" \
     --enable-shared \
     --disable-static
-make -j "$(nproc)"
-make install
+
+# SUBDIRS is overridden to skip examples/. They call nc_set_log_level, which
+# netcdf-c only exports when built --enable-logging, so they fail to link
+# against our build. 4.3.1 has no --disable-examples. The library, all the
+# headers including the <netcdf> umbrella, and the pkg-config file are still
+# installed.
+make -j "$(nproc)" SUBDIRS=cxx4
+make install SUBDIRS=cxx4
 ldconfig
 echo "::endgroup::"
 
 echo "NetCDF C++4 installed:"
 ls -l "${PREFIX}"/lib*/libnetcdf_c++4.so* "${PREFIX}/include/netcdf"
+
+# Fail loudly here rather than shipping a wheel that quietly regained the
+# dependency this script exists to avoid.
+if ldd "${PREFIX}"/lib*/libnetcdf.so | grep -q libcurl; then
+    echo "ERROR: libnetcdf still links libcurl; DAP or byterange is enabled." >&2
+    exit 1
+fi
+echo "Confirmed: libnetcdf does not link libcurl."


### PR DESCRIPTION
Halves the Linux wheel by building NetCDF without features ForeFire does not use.

| | Before | After |
| --- | --- | --- |
| Compressed | 8.6 MB | **4.0 MB** |
| Unpacked | 23.3 MB | **12.0 MB** |
| Vendored libraries | 32 | **6** |

## What was in there

EPEL's `netcdf` package enables DAP (reading datasets over HTTP) and HDF4. `auditwheel` correctly vendors their entire dependency closure, so a wheel whose own code is 2.6 MB was shipping:

```
libcurl, libcrypto, libssl, libkrb5, libgssapi_krb5, libk5crypto,
libkrb5support, libcom_err, libkeyutils, libldap, liblber, libsasl2,
libssh, libnghttp2, libbrotlicommon, libbrotlidec, libpsl, libidn2,
libunistring, libselinux, libpcre2, libcrypt      <- 10.2 MB, DAP
libmfhdf, libdf, libjpeg, libtirpc                <-  1.4 MB, HDF4
```

26 of 32 libraries. ForeFire opens local `.nc` files and Meso-NH `PGD` files, so neither feature is reachable from it.

The security side matters more than the size. That list includes OpenSSL 1.1.1k, which is past end of life, plus Kerberos, LDAP and libssh. Any scanner pointed at an installed `forefire` flags them, and we would be respinning wheels for CVEs in code the simulator never calls.

## What changed

`tools/devops/install-netcdf-manylinux.sh` now builds `netcdf-c` 4.9.3 from source, checksum pinned, rather than installing `netcdf-devel` from EPEL:

```
--disable-dap --disable-byterange --disable-hdf4 --disable-libxml2
```

`--disable-byterange` is needed as well as `--disable-dap`, because byterange is a second remote-access path that links libcurl on its own. HDF5 still comes from EPEL. `netcdf-cxx4` was already built from source and is unchanged, other than skipping its `examples/` directory: they call `nc_set_log_level`, which `netcdf-c` only exports when built `--enable-logging`, and 4.3.1 has no `--disable-examples`.

The script now fails if `libnetcdf` regains a libcurl dependency, so a future change to the base image cannot quietly undo this.

## Effect on platform consistency

Mixed, and worth a decision rather than a nod:

- **HDF4: this removes an inconsistency.** Homebrew's NetCDF has never enabled it, so the macOS wheel already could not read HDF4 files while the Linux one could. They now agree.
- **DAP: this introduces one.** macOS keeps DAP, because its `libnetcdf` resolves libcurl to `/usr/lib/libcurl.4.dylib`, a system library `delocate` leaves alone. It costs nothing there, so there was no reason to build NetCDF from source on macOS just to remove it. If you would rather the two match exactly, say so and I will do the same on macOS.

The remaining 6 libraries are `libnetcdf`, `libnetcdf_c++4`, `libhdf5`, `libhdf5_hl`, `libsz` and `libaec`, which is the same core set the macOS wheel carries.

## Verification

Built in a clean `manylinux_2_28_x86_64` container with podman, installed into a fresh venv on a Fedora 44 host that has no NetCDF of its own:

| Check | Result |
| --- | --- |
| Smoke test `tests/python/test_wheel.py` | passes, 122 fire nodes |
| `forefire -v` | `v2.5.0` |
| Repository example `tests/runff/run.ff` | exit 0, GeoJSON 1625 bytes, byte-identical to the current wheel |
| `libnetcdf` links libcurl | no, and the script now asserts it |

## Open question

Does anything in ForeFire or the Meso-NH coupling read datasets over OPeNDAP, or open HDF4 files? I could not find a path to either, but the coupling is the part I know least. If one of them is genuinely used, the right answer is to enable it deliberately on both platforms instead, and this should be closed.

---

*This pull request, including its code changes and this description, was generated by Claude Opus 5.*
