### PR TITLE
Stop shipping free-threaded (cp314t) wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering",
   "Operating System :: POSIX :: Linux",
   "Operating System :: MacOS :: MacOS X",
@@ -82,7 +83,13 @@ regex = '''ff_version\s*=\s*"v?(?P<value>\d+\.\d+\.\d+)"'''
 [tool.cibuildwheel]
 # 32-bit and musl targets have no usable NetCDF C++4 story, and PyPy cannot
 # load the pybind11 module built here.
-skip = ["pp*", "*-musllinux_*", "*_i686", "*-win32"]
+# cp314t is the free-threaded build. An extension that does not declare
+# `py::mod_gil_not_used()` makes the interpreter re-enable the GIL on import,
+# so such a wheel advertises free-threading while silently switching it off.
+# _pyforefire makes no such declaration, and the C++ core keeps mutable global
+# state (see FireDomain's model registries and SimulationParameters), so it is
+# not safe to run without the GIL. Revisit only once that is addressed.
+skip = ["pp*", "*-musllinux_*", "*_i686", "*-win32", "cp314t-*"]
 test-command = [
   "python {project}/tests/python/test_wheel.py",
   "forefire -v",


### PR DESCRIPTION
v2.5.0 + CPython 3.14 shipped free-threaded wheels. It should not have, and this stops it until the architecture is changed.

```
forefire-2.5.0-cp314-cp314t-manylinux_2_27_x86_64...whl
forefire-2.5.0-cp314-cp314t-macosx_14_0_arm64.whl
```

cibuildwheel built `cp314t` because nothing in `skip` excluded it. My oversight in #151: I assumed free-threaded builds were opt-in.

## Why that is a problem

A free-threaded wheel tells users the extension is safe without the GIL. `_pyforefire.cpp` uses a plain `PYBIND11_MODULE` with no `py::mod_gil_not_used()`, so CPython re-enables the GIL when it is imported. The wheel advertises free-threading and then silently switches it off. Users get a slower interpreter and a promise that was never kept.

The core could not honour that promise regardless. Searching `src/` for `std::mutex`, `std::atomic`, `lock_guard`, `pthread_mutex` or OpenMP critical sections returns **zero matches** across roughly 33,000 lines. Concretely:

| Shared state | Where | Problem without the GIL |
| --- | --- | --- |
| `SimulationParameters::instance` | `SimulationParameters.cpp:28` | `if (instance == 0) instance = new SimulationParameters;` Two threads can both allocate, then diverge with different parameter objects. |
| `ForeFireAtom::instanceNRCount` | `ForeFireAtom.h:106` | Every object's ID comes from `instanceNRCount++`, non-atomic. Concurrent construction races and can duplicate IDs. |
| `FireDomain::propModelsTable` | `FireDomain.cpp:58,697,859` | A process-wide array of 50 slots, scanned for a free index and written at runtime. Two domains compete for the same slots. |
| `FireNode::nmlScheme`, `smoothing`, `relax`, `minSpeed`, `minFrontDepth` | `FireNode.cpp:22-30` | Per-class mutable settings shared by every node in the process. |

None of this is a bug today. The binding never calls `gil_scoped_release`, so the GIL serialises every entry point, and ForeFire is a single-simulation-per-process design. The GIL is exactly what makes it safe, which is why a wheel built to run without one is the wrong thing to publish.

## Changes

- `cp314t-*` added to `[tool.cibuildwheel] skip`, with a comment recording why, so it is not removed casually.
- `Programming Language :: Python :: 3.14` added to the classifiers. The regular cp314 wheels do build and pass CI, and the classifier list stopped at 3.13, so this closes the gap raised in #151.

Regular CPython 3.14 wheels are unaffected and keep shipping.

## If free-threading is wanted later

It is a real piece of work, not a flag: give the singleton a thread-safe initialiser, make the ID counter atomic, move the model table and the FireNode settings off class-wide storage, then audit `FireDomain` and `DataBroker` for shared mutable state, and only then declare `py::mod_gil_not_used()`. Worth its own issue if anyone wants it.

---

*This pull request, including its code changes and this description, was generated by Claude Opus 5.*
