### PR TITLE
Stop freeing the model properties array twice

### DIFF
--- a/src/flux/BurnupHeatFluxModel.cpp
+++ b/src/flux/BurnupHeatFluxModel.cpp
@@ -88,7 +88,6 @@ BurnupHeatFluxModel::BurnupHeatFluxModel(
 
 /* destructor (shoudn't be modified) */
 BurnupHeatFluxModel::~BurnupHeatFluxModel() {
-	if ( properties != 0 ) delete properties;
 }
 
 /* accessor to the name of the model */

--- a/src/flux/CraterHeatFluxModel.cpp
+++ b/src/flux/CraterHeatFluxModel.cpp
@@ -112,7 +112,6 @@ CraterHeatFluxModel::CraterHeatFluxModel(
 
 /* destructor (shoudn't be modified) */
 CraterHeatFluxModel::~CraterHeatFluxModel() {
-	if ( properties != 0 ) delete properties;
 }
 
 /* accessor to the name of the model */

--- a/src/flux/CraterVaporFluxModel.cpp
+++ b/src/flux/CraterVaporFluxModel.cpp
@@ -93,7 +93,6 @@ CraterVaporFluxModel::CraterVaporFluxModel(
 
 /* destructor (shoudn't be modified) */
 CraterVaporFluxModel::~CraterVaporFluxModel() {
-	if ( properties != 0 ) delete properties;
 }
 
 /* accessor to the name of the model */

--- a/src/flux/FactorChemFluxModel.cpp
+++ b/src/flux/FactorChemFluxModel.cpp
@@ -100,7 +100,6 @@ FactorChemFluxModel::FactorChemFluxModel(
 
 /* destructor (shoudn't be modified) */
 FactorChemFluxModel::~FactorChemFluxModel() {
-	if ( properties != 0 ) delete properties;
 }
 
 /* accessor to the name of the model */

--- a/src/flux/ForeFireV1HeatFluxModel.cpp
+++ b/src/flux/ForeFireV1HeatFluxModel.cpp
@@ -116,7 +116,6 @@ ForeFireV1HeatFluxModel::ForeFireV1HeatFluxModel(
 
 /* destructor (shoudn't be modified) */
 ForeFireV1HeatFluxModel::~ForeFireV1HeatFluxModel() {
-	if ( properties != 0 ) delete properties;
 }
 
 /* accessor to the name of the model */

--- a/src/flux/ForeFireV1VaporFluxModel.cpp
+++ b/src/flux/ForeFireV1VaporFluxModel.cpp
@@ -112,7 +112,6 @@ ForeFireV1VaporFluxModel::ForeFireV1VaporFluxModel(
 
 /* destructor (shoudn't be modified) */
 ForeFireV1VaporFluxModel::~ForeFireV1VaporFluxModel() {
-	if ( properties != 0 ) delete properties;
 }
 
 /* accessor to the name of the model */

--- a/src/flux/HeatFluxBasicModel.cpp
+++ b/src/flux/HeatFluxBasicModel.cpp
@@ -78,7 +78,6 @@ HeatFluxBasicModel::HeatFluxBasicModel(
 
 /* destructor (shoudn't be modified) */
 HeatFluxBasicModel::~HeatFluxBasicModel() {
-	if ( properties != 0 ) delete properties;
 }
 
 /* accessor to the name of the model */

--- a/src/flux/HeatFluxFromObsModel.cpp
+++ b/src/flux/HeatFluxFromObsModel.cpp
@@ -152,7 +152,6 @@ HeatFluxFromObsModel::HeatFluxFromObsModel(
 
 /* destructor (shoudn't be modified) */
 HeatFluxFromObsModel::~HeatFluxFromObsModel() {
-	if ( properties != 0 ) delete properties;
 }
 
 /* accessor to the name of the model */

--- a/src/flux/HeatFluxNominalModel.cpp
+++ b/src/flux/HeatFluxNominalModel.cpp
@@ -75,7 +75,6 @@ HeatFluxNominalModel::HeatFluxNominalModel(
 
 /* destructor (shoudn't be modified) */
 HeatFluxNominalModel::~HeatFluxNominalModel() {
-	if ( properties != 0 ) delete properties;
 }
 
 /* accessor to the name of the model */

--- a/src/flux/LavaSO2FluxModel.cpp
+++ b/src/flux/LavaSO2FluxModel.cpp
@@ -98,7 +98,6 @@ LavaSO2FluxModel::LavaSO2FluxModel(
 
 /* destructor (shoudn't be modified) */
 LavaSO2FluxModel::~LavaSO2FluxModel() {
-	if ( properties != 0 ) delete properties;
 }
 
 /* accessor to the name of the model */

--- a/src/flux/ScalarFluxNominalModel.cpp
+++ b/src/flux/ScalarFluxNominalModel.cpp
@@ -75,7 +75,6 @@ ScalarFluxNominalModel::ScalarFluxNominalModel(
 
 /* destructor (shoudn't be modified) */
 ScalarFluxNominalModel::~ScalarFluxNominalModel() {
-	if ( properties != 0 ) delete properties;
 }
 
 /* accessor to the name of the model */

--- a/src/flux/ScalarFromObsModel.cpp
+++ b/src/flux/ScalarFromObsModel.cpp
@@ -99,7 +99,6 @@ ScalarFromObsModel::ScalarFromObsModel(
 
 /* destructor (shoudn't be modified) */
 ScalarFromObsModel::~ScalarFromObsModel() {
-	if ( properties != 0 ) delete properties;
 }
 
 /* accessor to the name of the model */

--- a/src/flux/SpottingFluxBasicModel.cpp
+++ b/src/flux/SpottingFluxBasicModel.cpp
@@ -100,7 +100,6 @@ SpottingFluxBasicModel::SpottingFluxBasicModel(
 
 /* destructor (shoudn't be modified) */
 SpottingFluxBasicModel::~SpottingFluxBasicModel() {
-	if ( properties != 0 ) delete properties;
 }
 
 /* accessor to the name of the model */

--- a/src/flux/VaporFluxBasicModel.cpp
+++ b/src/flux/VaporFluxBasicModel.cpp
@@ -77,7 +77,6 @@ VaporFluxBasicModel::VaporFluxBasicModel(
 
 /* destructor (shoudn't be modified) */
 VaporFluxBasicModel::~VaporFluxBasicModel() {
-	if ( properties != 0 ) delete properties;
 }
 
 /* accessor to the name of the model */

--- a/src/flux/VaporFluxFromObsModel.cpp
+++ b/src/flux/VaporFluxFromObsModel.cpp
@@ -75,7 +75,6 @@ VaporFluxFromObsModel::VaporFluxFromObsModel(
 
 /* destructor (shoudn't be modified) */
 VaporFluxFromObsModel::~VaporFluxFromObsModel() {
-	if ( properties != 0 ) delete properties;
 }
 
 /* accessor to the name of the model */

--- a/src/flux/VaporFluxNominalModel.cpp
+++ b/src/flux/VaporFluxNominalModel.cpp
@@ -74,7 +74,6 @@ VaporFluxNominalModel::VaporFluxNominalModel(
 
 /* destructor (shoudn't be modified) */
 VaporFluxNominalModel::~VaporFluxNominalModel() {
-	if ( properties != 0 ) delete properties;
 }
 
 /* accessor to the name of the model */

--- a/src/propagation/ANNPropagationModel.cpp
+++ b/src/propagation/ANNPropagationModel.cpp
@@ -73,9 +73,6 @@ ANNPropagationModel::ANNPropagationModel(const int & mindex, DataBroker* db)
 
 
 ANNPropagationModel::~ANNPropagationModel() {
-    if (properties) {
-        delete[] properties;
-    }
 }
 
 /* accessor to the name of the model */

--- a/src/propagation/BMapLoggerForANNTraining.cpp
+++ b/src/propagation/BMapLoggerForANNTraining.cpp
@@ -79,9 +79,6 @@ BMapLoggerForANNTraining::BMapLoggerForANNTraining(const int & mindex, DataBroke
 
 
 BMapLoggerForANNTraining::~BMapLoggerForANNTraining() {
-    if (properties) {
-        delete[] properties;
-    }
         if (csvfile.is_open()) {
         csvfile.close();
     }

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -74,29 +74,26 @@ do not trip it. A pin moving means the model changed; that may well be
 intended, but it should be a decision rather than a surprise. The pins carry
 no claim of matching published values.
 
-## Things found while writing these, and not fixed here
-
-Two of them are why `test_model_registry.cpp` only destroys the models that
-register no properties.
+## Things found while writing these
 
 **Models are never destroyed in a normal run.** `FireDomain` keeps them in
 `propModelsTable` and `fluxModelsTable` and frees neither, so every model a
-simulation instantiates is leaked. That is why the two problems below have
-never been observed: the code that would trip them does not run.
+simulation instantiates is leaked. That is why the two memory bugs below went
+unnoticed for so long: the code that trips them does not otherwise run. Still
+open.
 
-**The `properties` array is deleted twice.** Seventeen flux models and two
-propagation models delete `properties` in their own destructor, and
-`~ForeFireModel` deletes it again. Most of them also use scalar `delete` on an
-array allocated with `new[]`. So destroying any model that registers at least
-one property is a double free. Fixing it means removing the `delete` from each
-derived destructor and leaving it to the base class — nineteen files, worth
-doing as its own change.
+**The `properties` array was deleted twice** — fixed, along with the test that
+holds it fixed. Sixteen flux models and two propagation models deleted
+`properties` in their own destructor while `~ForeFireModel` deleted it again,
+and the flux ones used scalar `delete` on an array allocated with `new[]`. It is
+allocated by each model's constructor and freed by the base class, so the
+derived deletes are simply gone. `every model can be destroyed` covers all 33
+models; reintroduce one delete and it aborts with `double free or corruption`.
 
-`~ForeFireModel` itself was fixed while writing these tests: it left
-`properties` uninitialised, so destroying a model that registers *no*
-properties — `Iso`, `heatFluxBasic` — deleted whatever the member happened to
-be built over. It also deleted `fuelPropertiesTable`, allocated with a scalar
-`new`, with `delete[]`.
+`~ForeFireModel` itself left `properties` uninitialised, so destroying a model
+that registers *no* properties — `Iso`, `heatFluxBasic` — deleted whatever the
+member happened to be built over. It also freed `fuelPropertiesTable`, allocated
+with a scalar `new`, using `delete[]`. Both fixed.
 
 **`BalbiNov2011` responds non-physically to live fuel moisture at the values
 in the shipped fuel table.** `xsi` exceeds 1 for fuel 1 of

--- a/tests/unit/test_model_registry.cpp
+++ b/tests/unit/test_model_registry.cpp
@@ -116,30 +116,52 @@ TEST_CASE("an unknown model name is refused rather than fatal") {
     CHECK(flux == 0);
 }
 
-TEST_CASE("a model with no properties can be destroyed") {
-    // Models that register no property never allocate their `properties`
-    // array, so they are the ones that expose whatever the base class leaves
-    // uninitialised: ~ForeFireModel deletes that pointer unconditionally.
-    // Iso is on the default path — it is what tests/python and test_wheel.py
-    // run — so this has to be safe.
+TEST_CASE("every model can be destroyed") {
+    // `properties` is allocated by each model's own constructor with
+    // new double[numProperties] and freed by ~ForeFireModel. Freeing it in a
+    // derived destructor as well is a double free, and this case is what says
+    // so: run it under a build that reintroduces one and it aborts.
     //
-    // Nothing deletes a model in a normal run: FireDomain keeps them in
-    // propModelsTable and fluxModelsTable and never frees either, so the
-    // destructors below are reached only from here. That is also why this case
-    // covers only the property-less models: the ones that do allocate delete
-    // `properties` in their own destructor *and* inherit the base class doing
-    // it again, so destroying them is a double free. See tests/unit/README.md.
+    // Nothing deletes a model in a normal run — FireDomain keeps them in
+    // propModelsTable and fluxModelsTable and never frees either — so these
+    // destructors are reached only from here. That is precisely why the double
+    // free survived: the code that trips it does not otherwise run.
     ModelSandbox sandbox;
 
-    PropagationModel* iso = sandbox.propagation("Iso");
-    REQUIRE(iso != 0);
-    REQUIRE(iso->numProperties == 0);
-    delete iso;
+    const std::vector<std::string>& props = propagationModels();
+    for (size_t i = 0; i < props.size(); i++) {
+        CAPTURE(props[i]);
+        PropagationModel* model = sandbox.propagation(props[i]);
+        REQUIRE(model != 0);
+        delete model;
+    }
 
-    FluxModel* heat = sandbox.flux("heatFluxBasic");
-    REQUIRE(heat != 0);
-    REQUIRE(heat->numProperties == 0);
-    delete heat;
+    const std::vector<std::string>& fluxes = fluxModels();
+    for (size_t i = 0; i < fluxes.size(); i++) {
+        CAPTURE(fluxes[i]);
+        FluxModel* model = sandbox.flux(fluxes[i]);
+        REQUIRE(model != 0);
+        delete model;
+    }
+}
+
+TEST_CASE("destroying a model does not disturb the next one") {
+    // A double free often shows up as the *next* allocation coming back
+    // corrupted rather than as an immediate abort, so allocate across the
+    // destruction and check the new model is intact.
+    ModelSandbox sandbox;
+
+    PropagationModel* first = sandbox.propagation("Rothermel");
+    REQUIRE(first != 0);
+    const std::vector<std::string> wanted = first->wantedProperties;
+    const size_t count = first->numProperties;
+    delete first;
+
+    PropagationModel* second = sandbox.propagation("Rothermel");
+    REQUIRE(second != 0);
+    CHECK(second->numProperties == count);
+    CHECK(second->wantedProperties == wanted);
+    delete second;
 }
 
 TEST_CASE("property registration order is stable within a model") {


### PR DESCRIPTION
# Stop freeing the model `properties` array twice

**Stacked on #156** — targets `test/model-unit-suite`, so the diff below is only this change. Merge #156 first and GitHub will retarget this to `dev` automatically.

`properties` is allocated by each model's own constructor with `new double[numProperties]` and freed by `~ForeFireModel`. Sixteen flux models and two propagation models freed it *again* in their own destructor, so destroying any model that registers at least one property was a double free. The flux ones compounded it by using scalar `delete` on an array allocated with `new[]`.

Removing the derived deletes and leaving it to the base class is the whole fix. No ownership changes, no signature changes — 18 files, 22 lines deleted.

```diff
 /* destructor (shoudn't be modified) */
 HeatFluxBasicModel::~HeatFluxBasicModel() {
-	if ( properties != 0 ) delete properties;
 }
```

## Why this has never crashed anyone

`FireDomain` keeps its models in `propModelsTable` and `fluxModelsTable` and frees neither, so **nothing destroys a model today** — every model a simulation instantiates is leaked instead. The bug is unreachable in production and becomes reachable the moment anything does destroy one, including a test.

That leak is still open after this PR. It is a separate change, and fixing it *before* this one would have turned a silent leak into a crash on every run.

## The test comes with the fix

#156 deliberately limited its destructor case to the six models that register no properties, precisely because destroying the others was a double free. That restriction lifts here:

- **`every model can be destroyed`** now runs all 33 models — 17 propagation, 16 flux — instead of two.
- **`destroying a model does not disturb the next one`** allocates a model across a destruction and checks it comes back intact, because a double free often surfaces as the *next* allocation being corrupted rather than as an immediate abort.

Verified by reintroducing a single `delete` into `ForeFireV1HeatFluxModel` and re-running:

```
double free or corruption (!prev)
test_model_registry.cpp:119: FATAL ERROR: test case CRASHED: SIGABRT
[doctest] test cases: 1 | 0 passed | 1 failed
```

So the test genuinely holds the fix in place rather than merely passing alongside it. Worth noting the first attempt at that control used `heatFluxBasic` and passed — it registers no properties, so the `!= 0` guard made the reintroduced delete a no-op. The bug only bites models that actually allocate.

## Verification

- 22 cases, 2115 assertions, all passing; `ctest` 3/3.
- `tests/runff` unchanged — KML and NetCDF both within tolerance.
- Negative control above.

AddressSanitizer would have been the natural tool here, but glibc's own heap checking catches this one just as decisively, and the suite needs no special build to do it.
