### PR TITLE
Add the concurrency stress test that reproduces #175

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -83,6 +83,34 @@ global state, so a second `ForeFire()` in one process inherits the first one's
 parameters and a parameter sweep silently returns one identical result. Keep
 that in mind when writing any new Python test that varies parameters.
 
+## Running the Concurrency Stress Test (`test_threading.py`)
+
+Not run in CI, deliberately. On an ordinary interpreter the GIL serialises
+every call into the extension, so the test skips and would report a green
+result that proves nothing. It is a reproduction tool, run by hand when
+working on the shared-state problem in
+[#175](https://github.com/forefireAPI/forefire/issues/175).
+
+It runs eight simulations in threads and requires each to reproduce the fire
+node count it produces when run alone, plus a case that hammers object
+construction to exercise the shared id counter.
+
+**To run it**, you need a free-threaded build of CPython (`python3.14t` or
+later) and `PYTHON_GIL=0`. The variable is required: `_pyforefire` does not
+declare `py::mod_gil_not_used()`, so importing it switches the GIL back on and
+the test skips.
+
+```bash
+python3.14t -m venv .venv
+./.venv/bin/python -m pip install .
+PYTHON_GIL=0 ./.venv/bin/python tests/python/test_threading.py
+```
+
+**It does not pass today.** On `dev` it segfaults or returns wrong node counts,
+which is the point — it is the failing test the work in #175 has to make pass.
+Wiring it into CI belongs with the last step of that issue, once it can pass
+for the right reason.
+
 ## Other Tests
 
 The `tests/` directory contains other subdirectories (`mnh_*`, `runANN`) for testing specific features like coupled simulations. A main `tests/run.bash` script exists but is not currently fully validated in CI. Refer to specific subdirectories for details if needed.

--- a/tests/python/test_threading.py
+++ b/tests/python/test_threading.py
@@ -1,0 +1,149 @@
+"""Concurrency stress test for running several simulations in one process.
+
+ForeFire keeps simulation state in process-wide statics, so two domains
+running at the same time can corrupt each other. Under a normal CPython the
+GIL serialises every call into the extension and hides all of it, which is why
+this test only means anything on a free-threaded interpreter with the GIL
+actually off:
+
+    PYTHON_GIL=0 python3.14t tests/python/test_threading.py
+
+`PYTHON_GIL=0` is needed because `_pyforefire` does not declare
+`py::mod_gil_not_used()`, so importing it would otherwise switch the GIL back
+on and the test would pass without proving anything.
+
+Exit status is 0 only if every thread produced exactly the result it produces
+when run alone.
+"""
+
+import os
+import sys
+import threading
+import traceback
+
+SIZE = 1000
+STEPS = 5
+THREADS = 8
+
+
+def gil_enabled():
+    """True if the GIL is active, None if this interpreter has no switch."""
+    if not hasattr(sys, "_is_gil_enabled"):
+        return None
+    return sys._is_gil_enabled()
+
+
+def run_simulation(seed):
+    """One self-contained simulation. Returns its fire node count."""
+    import pyforefire
+
+    ff = pyforefire.ForeFire()
+    ff.execute(f"FireDomain[sw=(0,0,0);ne=({SIZE},{SIZE},0);t=0]")
+    ff.addLayer("propagation", "Iso", "propagationModel")
+    ff.execute(f"startFire[loc=({SIZE / 2},{SIZE / 2},0)]")
+    for _ in range(STEPS):
+        ff.execute("step[dt=100]")
+    return ff.execute("print[]").count("FireNode")
+
+
+def test_concurrent_domains(baseline):
+    """Every thread must reproduce the single-threaded result exactly."""
+    results = [None] * THREADS
+    errors = [None] * THREADS
+
+    def worker(i):
+        try:
+            results[i] = run_simulation(i)
+        except BaseException:
+            errors[i] = traceback.format_exc()
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(THREADS)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    failures = []
+    for i, err in enumerate(errors):
+        if err is not None:
+            failures.append(f"thread {i} raised:\n{err}")
+    for i, got in enumerate(results):
+        if errors[i] is None and got != baseline:
+            failures.append(f"thread {i} produced {got} fire nodes, expected {baseline}")
+    return failures
+
+
+def test_concurrent_construction():
+    """Hammer object creation, which draws IDs from a shared counter.
+
+    Every ForeFireAtom takes its id from `instanceNRCount++`, which is not
+    atomic, so concurrent construction can hand the same id to two objects.
+    """
+    import pyforefire
+
+    made = []
+    lock = threading.Lock()
+    errors = []
+
+    def worker():
+        try:
+            local = [pyforefire.ForeFire() for _ in range(25)]
+            with lock:
+                made.extend(local)
+        except BaseException:
+            with lock:
+                errors.append(traceback.format_exc())
+
+    threads = [threading.Thread(target=worker) for _ in range(THREADS)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    if errors:
+        return [f"construction raised:\n{errors[0]}"]
+    expected = THREADS * 25
+    if len(made) != expected:
+        return [f"created {len(made)} objects, expected {expected}"]
+    return []
+
+
+def main():
+    # Import before reading the GIL state. An extension that does not declare
+    # `py::mod_gil_not_used()` switches the GIL back on as it is imported, so
+    # checking beforehand reports the interpreter's default rather than the
+    # state this test actually runs under.
+    before = gil_enabled()
+    import pyforefire  # noqa: F401
+
+    gil = gil_enabled()
+    print(f"interpreter: {sys.version.split()[0]}")
+    print(f"GIL enabled: {gil} (was {before} before importing pyforefire)")
+    if gil is None:
+        print("SKIP: not a free-threaded interpreter, this test cannot prove anything")
+        return 0
+    if gil:
+        print(
+            "SKIP: the GIL is on, so every call is serialised and races stay hidden.\n"
+            "      Re-run with PYTHON_GIL=0 to actually exercise concurrency."
+        )
+        return 0
+
+    baseline = run_simulation(0)
+    print(f"single-threaded baseline: {baseline} fire nodes")
+
+    failures = []
+    failures += test_concurrent_domains(baseline)
+    failures += test_concurrent_construction()
+
+    if failures:
+        print(f"\nFAILED with {len(failures)} problem(s):")
+        for f in failures[:10]:
+            print(f"  - {f}")
+        return 1
+    print(f"\nOK: {THREADS} concurrent simulations all matched the baseline")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The reproduction harness for #175, plus the documentation for running it. No changes to `src/`.

Eight threads, each building a 1000×1000 domain with the `Iso` propagation model, igniting at the centre and stepping five times. Each thread must reproduce the fire node count it produces when run alone. A second case hammers object construction, which draws every id from one shared counter.

## What it measures

Built from source against CPython 3.14.6 free-threading in a manylinux_2_28 container:

| Build | Same 8 threads, GIL **on** | GIL **off**, 5 runs |
| --- | --- | --- |
| `dev` @ `e1df887` | 3/3 pass | 4 × segfault, 1 × wrong results |
| `dev` + the small fixes proposed in #175 | — | 4 × segfault, 1 × abort |
| full free-threading branch | pass | 5/5 pass |

The GIL-on column is the control: identical workload, identical code, passing every time. The only variable is whether the calls are serialised.

The one crash-free run on `dev` is the interesting one:

```
single-threaded baseline: 62 fire nodes
FAILED with 7 problem(s):
  - thread 1 produced 49 fire nodes, expected 62
  - thread 3 produced 209 fire nodes, expected 62
  - thread 4 produced 27 fire nodes, expected 62
```

Wrong answers rather than a crash, which is the worse failure of the two.

## Deliberately not wired into CI

On an ordinary interpreter the GIL serialises every call into the extension, so the test skips and exits 0. A CI job would sit green while proving nothing — the same failure mode as a warning nobody reads. It earns a job at the end of #175, once it can pass for the right reason. Please do not add one as a follow-up before then.

`PYTHON_GIL=0` is required rather than optional: `_pyforefire` does not declare `py::mod_gil_not_used()`, so importing it switches the GIL back on, and the test would otherwise skip on a free-threaded interpreter too. It says so when that happens rather than passing quietly.

## What this does not do

It does not fix anything. It fails on `dev`, and it is meant to. Merging it makes the problem in #175 reproducible on demand; the fixes are separate pull requests, and by the measurements above only the full state refactor makes it pass.

`TESTING.md` gains a section covering the interpreter requirement, the invocation, and the fact that it currently fails.

---

*This pull request, including its code changes and this description, was generated by Claude Opus 5, and reviewed manually before submitting.*
