### PR TITLE
Make the atom id counter atomic and the parameters singleton safe

### DIFF
--- a/src/FireDomain.cpp
+++ b/src/FireDomain.cpp
@@ -27,7 +27,7 @@
  //  On fait plus de chaines....
  
 	 // Static variables
-	 long ForeFireAtom::instanceNRCount = 0;
+	 std::atomic<long> ForeFireAtom::instanceNRCount{0};
  
 	 const double FireDomain::endChain = -1.;
 	 const double FireDomain::endCom = -10.;

--- a/src/ForeFireAtom.h
+++ b/src/ForeFireAtom.h
@@ -11,6 +11,8 @@
 
 #include "include/Futils.h"
 
+#include <atomic>
+
 using namespace std;
 
 namespace libforefire{
@@ -33,7 +35,13 @@ namespace libforefire{
 class ForeFireAtom {
 private:
 
-	static long instanceNRCount; /*!< Instance Count */
+	/*! \brief Instance count, the source of every atom's id.
+	 *
+	 * Atomic because objects are created from more than one thread once the
+	 * GIL is out of the way, and a plain `++` there is a data race that can
+	 * hand the same id to two atoms.
+	 */
+	static std::atomic<long> instanceNRCount;
 
 	double time; /*!< current time of the object */
 	double updateTime; /*!< next update time */
@@ -103,7 +111,10 @@ public:
 		return getIDfromLongs((long) did/domainMult(),(long) did%domainMult());
 	}
 	void getNewID(const long& domainId){
-		numID = getIDfromLongs(domainId,instanceNRCount++);
+		// relaxed: ids only have to be distinct, not ordered against other
+		// memory operations.
+		numID = getIDfromLongs(domainId,
+				instanceNRCount.fetch_add(1, std::memory_order_relaxed));
 	}
 
 	/*! \brief Pure virtual function for inpus */

--- a/src/SimulationParameters.cpp
+++ b/src/SimulationParameters.cpp
@@ -17,8 +17,6 @@ namespace libforefire {
 
 
 	
-SimulationParameters* SimulationParameters::instance = 0;
-
 string SimulationParameters::undefined = "1234567890";
 double SimulationParameters::doubleUndefined = 1234567890.;
 int SimulationParameters::intUndefined = 1234567890;
@@ -26,7 +24,13 @@ size_t SimulationParameters::sizeUndefined = 1234567890;
 
 
 SimulationParameters* SimulationParameters::GetInstance(){
-	if ( instance == 0 ) instance =  new SimulationParameters;
+	// A function-local static: C++11 onwards guarantees its initialisation
+	// runs exactly once even if several threads arrive here together. The
+	// previous `if (instance == 0) instance = new ...` let two threads both
+	// see null and both construct, leaving them with different parameter
+	// objects. Never deleted, matching the previous behaviour; the parameters
+	// live for the whole process.
+	static SimulationParameters* const instance = new SimulationParameters();
 	return instance;
 }
 

--- a/src/SimulationParameters.h
+++ b/src/SimulationParameters.h
@@ -18,8 +18,6 @@ namespace libforefire {
 
 class SimulationParameters {
 
-    static SimulationParameters* instance; /*!< Singleton-type class */
-
     /*! values for undefined parameters */
     static string undefined;
 	static double doubleUndefined;


### PR DESCRIPTION
Two pieces of shared state from the table in #175, both fixed without adding any runtime machinery. Eight lines of substance.

## The id counter

Every `ForeFireAtom` takes its id from `instanceNRCount++` (`ForeFireAtom.h:106`), a plain `long`. Concurrent construction can hand the same id to two objects. It becomes `std::atomic<long>` with `fetch_add(1, std::memory_order_relaxed)` — relaxed because ids only have to be distinct, not ordered against anything else, so this compiles to the same `lock xadd` a compiler would emit anyway and costs nothing measurable on the single-threaded path.

## The parameters singleton

`GetInstance` was the textbook unsafe lazy singleton:

```cpp
if ( instance == 0 ) instance = new SimulationParameters;
```

Two threads can both see null, both construct, and walk away with different parameter objects. It becomes a function-local static, whose once-only initialisation C++11 already guarantees:

```cpp
static SimulationParameters* const instance = new SimulationParameters();
```

Still never deleted, matching what it did before — the parameters live for the whole process. The now-unused private `instance` member goes with it.

## What this does not do

**It does not make ForeFire safe to use from several threads.** I measured that: with this change and the other small fixes applied, the eight-thread stress test in #176 still crashes on all five runs. Safety needs the state refactor described as step 5 of #175, which is a real API change and is not proposed here.

What this does is remove two anti-patterns that are wrong on their own terms. The unsafe lazy singleton is a known bug shape whether or not anyone threads this code, and a shared mutable counter behind an `++` is the same. Neither change adds a lock, a flag, or a branch to any hot path.

## Verification

- Unit tests: 4/4 suites pass.
- `runff`: KML and NetCDF both match the references within tolerance. Ids are still allocated in the same order single-threaded, so the outputs are unchanged.
- Build is clean of new warnings.

Related: #175 (the shared-state issue), #176 (the stress test that measures it).

---

*This pull request, including its code changes and this description, was generated by Claude Opus 5, and reviewed manually before submitting.*
