### PR TITLE
Give each string representation its own buffer

### DIFF
--- a/src/StringRepresentation.cpp
+++ b/src/StringRepresentation.cpp
@@ -24,19 +24,21 @@ using namespace std;
 
 namespace libforefire {
 
-// static variables initialization
-size_t StringRepresentation::currentLevel = 0;
-ostringstream StringRepresentation::outputstr("");
+// The output buffer, the nesting level and the GeoJSON aggregation state used
+// to be statics and file globals here, so two simulations printing at the same
+// time wrote into one buffer. They are members now.
+//
+// For GEOJSON mode we aggregate rings per top-level front. Each top-level
+// feature (currentLevel==1) is a vector of rings, where each ring is a vector
+// of coordinate strings.
+//
+// writedOnce is deliberately left shared for now. Unlike the rest, making it
+// per-instance is an observable change: output() skips a representation whose
+// domain has no front once anything has been written, so a second
+// representation in the same session would gain a first output file it does
+// not produce today. That is a behaviour question for the coupled runs, not a
+// mechanical one, and it belongs with the state work in #175.
 bool writedOnce = false;
-string outPattern;
-FireDomain* domain = 0;
-
-// --- GEOJSON Aggregation Variables ---
-// For GEOJSON mode we aggregate rings per top-level front.
-// Each top-level feature (currentLevel==1) will be represented as a vector of rings,
-// where each ring is a vector of coordinate strings.
-static bool firstGeoFeature = true;  // used when outputting the feature list
-static std::vector< std::vector<std::string> > geojson_current_feature;
 
 StringRepresentation::StringRepresentation(FireDomain* fdom) : Visitor() {
     lastLevel = -1;

--- a/src/StringRepresentation.h
+++ b/src/StringRepresentation.h
@@ -18,13 +18,22 @@ namespace libforefire {
 class StringRepresentation: public Visitor {
 
 	FireDomain* domain;
-	static size_t currentLevel;
+
+	/* These were statics, shared by every simulation in the process: two
+	 * concurrent print[] calls interleaved into one buffer. */
+	size_t currentLevel = 0;
+	bool firstGeoFeature = true; /*!< first feature of the GeoJSON list */
+	std::vector< std::vector<std::string> > geojson_current_feature;
 
 	double updateStep;
 
 public:
 
-	static ostringstream outputstr;
+	/*! \brief buffer the representation is built into
+	 *
+	 * Was static, so two simulations printing at once interleaved into one
+	 * buffer. Command::dumpString reads it, hence public. */
+	ostringstream outputstr;
 
 /*	StringRepresentation();*/
 	StringRepresentation(FireDomain*);


### PR DESCRIPTION
`StringRepresentation` is a class you instantiate, but it kept its working state in statics and file-scope globals: the output buffer, the nesting level, and the GeoJSON ring aggregation. Two representations in one process share all of it. This makes them members.

It also removes two dead globals found along the way. The file-scope `outPattern` and `domain` were shadowed by members of the same name in every member function, so nothing ever read them.

## One part deliberately left alone

`writedOnce` stays a file-scope global. It is the only piece here whose conversion is observable rather than mechanical:

```cpp
if (writedOnce && (domain->getNumFF() == 0))
    return;
writedOnce = true;
```

Shared, the first representation to write suppresses the first output of any other whose domain has no front yet. Per-instance, that second representation would write one file it does not write today. A coupled session creates exactly two representations (`Command.cpp:205` and `232`), both scheduled as timetable events, so this is reachable in `masterMNH` runs.

Whether that extra file is wanted is a question for whoever runs the coupled cases, not something to decide inside a mechanical refactor. It is left as-is with a comment, for the state work in #175.

## What this does not do

It does not fix anything that misbehaves today. The buffer is safe under sequential use — `dumpStringRepresentation()` resets it before writing, as recorded in [this comment on #175](https://github.com/forefireAPI/forefire/issues/175#issuecomment-5270899908) — and it does not on its own make ForeFire safe to use from several threads. It removes a design smell: per-instance state that lives in a static.

## Verification

- **`rungeojson.ff` produces byte-identical output to `dev`**, both files: `5598d4b548bd7826546815f822b01073` and `177683c7bb42b267be6baa1d98ef5acd`. This is the important one — the GeoJSON aggregation state is what this change restructures, and `runff` does not cover that path.
- Unit tests: 4/4 suites pass.
- `runff`: KML and NetCDF both match the references within tolerance.

Related: #175 (the shared-state issue), #176 (stress test), #177 (the id counter and singleton).

---

*This pull request, including its code changes and this description, was generated by Claude Opus 5, and reviewed manually before submitting.*
