### PR TITLE
Add a CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,136 @@
+# Changelog
+
+All notable changes to ForeFire are recorded here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Version numbers are the tags in this repository and the values reported by
+`forefire -v`; they are also what `pip install forefire==<version>` resolves.
+
+Entries below v2.5.0 were reconstructed from the release notes and the commit
+history, so they summarise each release rather than list every change. The
+`Full Changelog` link on each version gives the complete commit range.
+
+## [Unreleased]
+
+Merged since v2.5.0, not yet released.
+
+### Changed
+
+- Linux wheels are built against a NetCDF without DAP and HDF4, roughly halving
+  the wheel. ([#154])
+- Free-threaded (`cp314t`) wheels are no longer published, because the core is
+  not yet thread-safe; CPython 3.14 is declared supported. ([#155])
+
+## [v2.5.0] — 2026-08-11
+
+### Added
+
+- **Pip-installable wheels** for Linux (x86_64, aarch64) and macOS (Apple
+  Silicon and Intel), CPython 3.9 and newer. `pip install forefire` gives both
+  the `forefire` command-line interpreter and the `pyforefire` module, with
+  NetCDF bundled inside the wheel. Wheels are built without MPI and without
+  `-march=native`. ([#151])
+
+### Changed
+
+- The Dockerfile is a multi-stage build, and only `libforefireL` is built in
+  the builder stage. ([#147])
+- The `install-forefire.sh` build is driven by an option-based `CMakeLists.txt`
+  (`FOREFIRE_ENABLE_MPI`, `FOREFIRE_NATIVE_ARCH`, `FOREFIRE_BUILD_PYTHON`,
+  `FOREFIRE_STATIC_CORE`, `FOREFIRE_BUILD_TOOLS`, `FOREFIRE_CHECK_LFS`).
+
+### Fixed
+
+- A double free in `FireFront` cleanup. ([#145])
+- `CMakeLists.txt` was matched by `.gitignore`, so it was missing from the
+  source distribution. ([#152])
+- Bugs in `tests/run.bash`, including a `runANN` typo and an unreachable
+  `./clean.bash`. ([#146])
+
+**Full Changelog**: <https://github.com/forefireAPI/forefire/compare/v2.4.2...v2.5.0>
+
+## [v2.4.2] — 2025-11-27
+
+- Simplified the installation process, following review comments on the JOSS
+  submission, and corrected the installation instructions.
+- Aligned the coupling with
+  [PACK-MNH-V5-7-2](https://src.koda.cnrs.fr/mesonh/mesonh-code/-/releases/PACK-MNH-V5-7-2).
+- Aligned the repository with the accepted JOSS paper
+  ([10.21105/joss.08680](https://doi.org/10.21105/joss.08680)).
+
+**Full Changelog**: <https://github.com/forefireAPI/forefire/compare/v2.1.122...v2.4.2>
+
+## [v2.1.122] — 2025-09-16
+
+Tagged, but never published as a GitHub release.
+
+- Docker images published to the GitHub container registry, and tested in CI.
+- Python bindings reworked, with the example from [#103] applied.
+- macOS CI runs the test script.
+
+**Full Changelog**: <https://github.com/forefireAPI/forefire/compare/v2.0...v2.1.122>
+
+## [v2.0] — 2025-06-05
+
+The V2 release: the HTTP interface, and alignment with Meso-NH V4.7.2.
+
+### Added
+
+- The built-in **HTTP command server and web UI** (`listenHTTP[]`, or
+  `forefire -l`), serving a map view of the simulation.
+- The **Read the Docs documentation site**, built with Sphinx, Breathe and
+  Doxygen.
+- `install-forefire.sh`, with `-y` to add `forefire` to `PATH` and set
+  `FOREFIREHOME`.
+- A working Dockerfile, and GitHub Actions for Linux and macOS.
+- The `RothermelAndrews2018` propagation model. ([#34])
+
+### Changed
+
+- CMake replaces SCons throughout; references to SCons were removed.
+
+### Fixed
+
+- The `-lnetcdf_c++4` link failure. ([#26])
+- A division by zero in `setArrivalTime`/`getArrivalTime`. ([#36])
+
+**Full Changelog**: <https://github.com/forefireAPI/forefire/compare/v1.2...v2.0>
+
+## [v1.2] — 2024-01-16
+
+### Added
+
+- The `geojson` dump mode.
+
+## [v1.1.10] — 2022-10-25
+
+### Changed
+
+- CMake became the default build system. ([#9])
+
+## [v1.1.0] — 2022-09-28
+
+Tagged before the sources were moved into `src/`, so that this point in the
+repository stays easy to return to.
+
+[Unreleased]: https://github.com/forefireAPI/forefire/compare/v2.5.0...dev
+[v2.5.0]: https://github.com/forefireAPI/forefire/releases/tag/v2.5.0
+[v2.4.2]: https://github.com/forefireAPI/forefire/releases/tag/v2.4.2
+[v2.1.122]: https://github.com/forefireAPI/forefire/releases/tag/v2.1.122
+[v2.0]: https://github.com/forefireAPI/forefire/releases/tag/v2.0
+[v1.2]: https://github.com/forefireAPI/forefire/releases/tag/v1.2
+[v1.1.10]: https://github.com/forefireAPI/forefire/releases/tag/v1.1.10
+[v1.1.0]: https://github.com/forefireAPI/forefire/releases/tag/v1.1.0
+
+[#9]: https://github.com/forefireAPI/forefire/issues/9
+[#26]: https://github.com/forefireAPI/forefire/pull/26
+[#34]: https://github.com/forefireAPI/forefire/pull/34
+[#36]: https://github.com/forefireAPI/forefire/pull/36
+[#103]: https://github.com/forefireAPI/forefire/issues/103
+[#145]: https://github.com/forefireAPI/forefire/pull/145
+[#146]: https://github.com/forefireAPI/forefire/pull/146
+[#147]: https://github.com/forefireAPI/forefire/pull/147
+[#151]: https://github.com/forefireAPI/forefire/pull/151
+[#152]: https://github.com/forefireAPI/forefire/pull/152
+[#154]: https://github.com/forefireAPI/forefire/pull/154
+[#155]: https://github.com/forefireAPI/forefire/pull/155

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,25 +64,28 @@ We welcome code contributions, from bug fixes to new features.
     Implement your code changes, following existing coding style and conventions where possible.
 6.  **Add Tests (if applicable):**
 
-    For new features or significant bug fixes, please add corresponding tests or update existing ones. See the [Testing Documentation](https://forefire.readthedocs.io/en/latest/developer_guide/testing.html) *(Placeholder: Link to testing section once created)* for details on how to run tests. Ensure all tests pass locally.
+    For new features or significant bug fixes, please add corresponding tests or update existing ones. See [TESTING.md](TESTING.md) for what each suite covers and how to run it. Ensure all tests pass locally.
     ```bash
     # Example command to run tests (adjust as needed)
     cd tests && bash run.bash
     ```
-7.  **Commit Changes:**
+7.  **Record the Change:**
+
+    Add an entry under `## [Unreleased]` in [CHANGELOG.md](CHANGELOG.md), in the section that fits (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Write it for someone upgrading: what changed for them, not what you edited. Skip this for changes with no user-visible effect, such as a typo fix or an internal refactor.
+8.  **Commit Changes:**
 
     Commit your changes with clear and concise commit messages.
     ```bash
     git add .
     git commit -m "feat: Implement new flux model calculation"
     ```
-8.  **Push to Your Fork:**
+9.  **Push to Your Fork:**
 
     Push your branch to your GitHub fork.
     ```bash
     git push origin my-feature-branch
     ```
-9.  **Open a Pull Request (PR):**
+10. **Open a Pull Request (PR):**
 
     Go to the `forefireAPI/forefire` repository on GitHub and open a Pull Request from your branch to the `dev` branch (or `master` if that's the target).
     *   Provide a clear description of the changes in the PR.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 - 📚 **Full Documentation:** [forefire.readthedocs.io](https://forefire.readthedocs.io/en/latest/)
 - 🚀 **Live Demo:** [forefire.univ-corse.fr/sim](http://forefire.univ-corse.fr/sim)
 - 🌍 **Website:** [forefire.univ-corse.fr](https://forefire.univ-corse.fr/)
+- 📝 **Changelog:** [CHANGELOG.md](CHANGELOG.md) — what each release changed
+- 🧪 **Testing:** [TESTING.md](TESTING.md) — how to run each test suite
 
 ## Features
 


### PR DESCRIPTION
The repository has seven tags and six GitHub releases, and no file that tells a user what changed between them. `pip install forefire` sharpened that: someone pinning a version has the release notes on GitHub and nothing in the tree.

## What is in it

Every release back to v1.1.0, reconstructed from the release notes and the commit history. It summarises each release rather than listing every commit — the `Full Changelog` link on each version gives the complete range.

Where a claim could be checked against the tags, it was:

| Claim | Check |
| --- | --- |
| `listenHTTP` is new in v2.0 | absent at `v1.2`, present at `v2.0` |
| `RothermelAndrews2018` is new in v2.0 | file absent at `v1.2`, present at `v2.0` |
| The `geojson` dump mode is new in v1.2 | absent at `v1.1.10` |

`v2.1.122` is in the file with a note that it was tagged but never published as a release, so the gap between v2.0 and v2.4.2 is not silently missing.

## `[Unreleased]` lists what is on this branch, not on dev

`master` is `v2.5.0` plus #154 and #155, so those two are all that appears. `dev` carries a longer list in its own copy — see the backport, which is this branch's file with entries added and nothing removed, so merging dev into master resolves it without a conflict.

## Also in here

- **`CONTRIBUTING.md` linked to a testing page that has never existed**, at `readthedocs.io/en/latest/developer_guide/testing.html`, marked `(Placeholder: Link to testing section once created)`. It points at `TESTING.md`, which until now nothing in the repository linked to at all.
- **A step asking for a changelog entry**, so the file stays current instead of being reconstructed again in a year. It says to skip changes with no user-visible effect, so it does not become a tax on typo fixes.
- **`README.md` Key Links** gains the changelog and `TESTING.md`.

## Not done here

`CONTRIBUTING.md` still says to verify with `cd tests && bash run.bash` next to "Ensure all tests pass locally". On this branch that instruction fails: `tests/run.bash` runs `runANN`, which has been broken since it was committed. The fix is #183, which is on `dev`, and the corrected wording travels with it — documenting a working command here would have been documenting something `master` cannot do yet.

The wider documentation audit that produced this — the Read the Docs site never mentioning `pip`, `tests/README.md` naming files that do not exist, the `emit` command missing from the console's own help — is not in this change.

---

*This pull request, including its code changes and this description, was generated by Claude Opus 5, and reviewed manually before submitting.*
